### PR TITLE
added lines to impb tex template to enable inline code representation

### DIFF
--- a/inst/rmarkdown/templates/heidelberg_thesis/skeleton/template_wo_chap_ipmb.tex
+++ b/inst/rmarkdown/templates/heidelberg_thesis/skeleton/template_wo_chap_ipmb.tex
@@ -20,6 +20,10 @@
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
 
+$if(highlighting-macros)$
+$highlighting-macros$
+$endif$       % For being able to set `echo = TRUE` in code chunk options, and thus in-line representation of code
+
 % -------------------------------
 % --- some layout definitions ---
 % -------------------------------


### PR DESCRIPTION
For now, I only did this for the IPMB template; note that it could probably also be added to the other two template files (even though I haven't tried knitting the pdf document with inline code for the other templates so far)